### PR TITLE
I can create a custom style in styles.xml

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,11 +13,14 @@
             <androidx.appcompat.widget.Toolbar
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
+                android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
+                android:background="?colorPrimaryDark"
                     android:layout_height="?attr/actionBarSize">
                 <ImageView
                         android:id="@+id/hero_image"
                         android:layout_width="150dp"
                         android:layout_height="match_parent"
+                    android:tint="?colorPrimary"
                         app:srcCompat="@drawable/logo"
                         android:contentDescription="@string/app_name"/>
             </androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -41,8 +41,8 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    style="@style/TextAppearance.Title"
                     android:text="@string/about_google_developer_groups"
+                    android:textAppearance="?attr/textAppearanceHeadline5"
                     app:layout_constraintEnd_toStartOf="@+id/end_grid"
                     app:layout_constraintStart_toStartOf="@+id/start_grid"
                     app:layout_constraintTop_toBottomOf="@id/image" />
@@ -59,12 +59,12 @@
 
                 <TextView
                     android:id="@+id/subtitle"
+                    android:textAppearance="?attr/textAppearanceHeadline6"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="13dp"
                     android:text="@string/gdgs_are"
                     android:textAllCaps="true"
-                    style="@style/TextAppearance.Title.Subtitle"
                     app:layout_constraintEnd_toStartOf="@id/end_grid"
                     app:layout_constraintStart_toEndOf="@id/start_grid"
                     app:layout_constraintTop_toBottomOf="@+id/intro_text" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,14 +8,11 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:fontFamily">@font/lobster_two</item>
         <item name="fontFamily">@font/lobster_two</item>
+        <item name="textAppearanceHeadline6">@style/CustomHeadline6</item>
     </style>
 
-    <style name="TextAppearance.Title" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="android:textSize">24sp</item>
-        <item name="android:textColor">#555555</item>
-    </style>
-
-    <style name="TextAppearance.Title.Subtitle" parent="TextAppearance.Title">
+    <style name="CustomHeadline6" parent="Base.TextAppearance.MaterialComponents.Headline6">
         <item name="android:textSize">18sp</item>
     </style>
+
 </resources>


### PR DESCRIPTION
however, it will override the AppTheme's other attributes (such as fontFamily) if I set that custom style to style attribute in textview. in this case, I can use textAppearance attribute of any widget(view) that has text component to apply custom style first then AppTheme can override rest (such as fontFamily) it is better to create a theme attribute in styles.xml and call it from layout xml file with textAppearance to take all other default values and custom values with out having it to override AppTheme in the app.